### PR TITLE
Last version corrected bug and added a few methods. Also there is a training script.

### DIFF
--- a/model.py
+++ b/model.py
@@ -86,7 +86,7 @@ class AudioMPS:
         batch_zeros = tf.zeros_like(data[:, 0])
         rho_0 = tf.stack(self.batch_size * [self.rho_0])
         loss = batch_zeros
-        data = tf.transpose(data, [1, 0])  # foldl goes along the first dimension
+        data = tf.transpose(data, [1, 0])  # foldl goes along the 1st dimension
         rho_0 = self._update_ancilla(rho_0, data[0])
         data = data[1:]
         _, loss = tf.foldl(self._rho_and_loss_update, data,

--- a/training.py
+++ b/training.py
@@ -11,7 +11,7 @@ BATCH_SIZE = 8
 
 # COHERENT STATE
 
-#theta = 2.*np.pi/3
+# theta = 2.*np.pi/3
 # phi = 2.*np.pi
 
 # INVERSE FREQUENCY OF THE SINE AND PHASE


### PR DESCRIPTION
This version of model.py contains the option to input the initial H, R and rho. Besides, I added 5 new methods: 
    rho_evolve_with_data: output rho(t), evolved with a note, no sampling.
    rho_with_sampling: output rho(t), evolved with  sampling.
    sample_time_evolved_rho0: samples neglecting the first term in log(p).
    purity: outputs purity(t).
    _rho_update: callable to be performed in the scanning, when we are only interested in updating the ancilla.